### PR TITLE
Add in-browser demo Space

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -10,11 +10,18 @@ _(*) State-of-the-art Facial Expression Recognition / Emotion Detection._
 [![style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/phamquiluan/residualmaskingnetwork)
 [![HF Paper](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Paper-yellow)](https://huggingface.co/papers/2603.05937)
 [![HF Model](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Model-yellow)](https://huggingface.co/phamquiluan/ResidualMaskingNetwork)
+[![HF Space](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Demo-orange)](https://huggingface.co/spaces/phamquiluan/ResidualMaskingNetwork)
 
 
 <p align="center">
 <img width=1000 src= "https://user-images.githubusercontent.com/24642166/284939631-ee2909f0-f084-47bb-8262-2c1728166fba.jpg"/>
 </p>
+
+## Live Demo
+
+Try it in your browser — [**huggingface.co/spaces/phamquiluan/ResidualMaskingNetwork**](https://huggingface.co/spaces/phamquiluan/ResidualMaskingNetwork).
+Inference runs entirely client-side through ONNX Runtime Web, so images never leave your
+machine. Source in [`space/`](space).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ _(*) State-of-the-art Facial Expression Recognition / Emotion Detection._
 ## Live Demo
 
 Try it in your browser — [**huggingface.co/spaces/phamquiluan/ResidualMaskingNetwork**](https://huggingface.co/spaces/phamquiluan/ResidualMaskingNetwork).
-Inference runs entirely client-side through ONNX Runtime Web, so images never leave your
-machine. Source in [`space/`](space).
+Inference runs entirely client-side through ONNX Runtime Web, so images
+never leave your machine. Source in [`space/`](space).
 
 ## Installation
 

--- a/rmn/__init__.py
+++ b/rmn/__init__.py
@@ -29,16 +29,60 @@ hf_repo_id = "phamquiluan/ResidualMaskingNetwork"
 checkpoint_filename = "Z_resmasking_dropout1_rot30_2019Nov30_13.32"
 yunet_checkpoint_filename = "face_detection_yunet_2023mar.onnx"
 
+github_release_url = (
+    "https://github.com/phamquiluan/ResidualMaskingNetwork/releases/download/v0.0.1"
+)
+
 # pre-downloaded files in the working directory take precedence,
 # otherwise checkpoints are fetched from the Hugging Face Hub cache
 local_checkpoint_path = "pretrained_ckpt"
 local_yunet_checkpoint_path = yunet_checkpoint_filename
 
-if not os.path.exists(local_checkpoint_path):
-    local_checkpoint_path = hf_hub_download(hf_repo_id, checkpoint_filename)
 
-if not os.path.exists(local_yunet_checkpoint_path):
-    local_yunet_checkpoint_path = hf_hub_download(hf_repo_id, yunet_checkpoint_filename)
+def download_from_github_release(filename, local_path):
+    """Stream a release asset to local_path, used when the Hub is unavailable."""
+    import requests
+
+    url = f"{github_release_url}/{filename}"
+    print(f"Downloading {url} -> {local_path}")
+
+    response = requests.get(url, stream=True, timeout=60)
+    response.raise_for_status()
+
+    # write to a temporary name so an interrupted download is never mistaken
+    # for a complete checkpoint on the next import
+    partial_path = f"{local_path}.part"
+    with open(partial_path, "wb") as ref:
+        for chunk in response.iter_content(chunk_size=1024 * 1024):
+            ref.write(chunk)
+    os.replace(partial_path, local_path)
+    return local_path
+
+
+def fetch_checkpoint(filename, local_path):
+    """Prefer the Hub, fall back to the GitHub release it used to ship from.
+
+    The Hub rate-limits unauthenticated downloads (HTTP 429), which is easy to
+    hit from CI matrices or shared IPs, and a rate limit should not make the
+    package unimportable.
+    """
+    if os.path.exists(local_path):
+        return local_path
+
+    try:
+        return hf_hub_download(hf_repo_id, filename)
+    except Exception as error:
+        print(
+            f"Hugging Face Hub download failed ({type(error).__name__}: {error}); "
+            "falling back to the GitHub release"
+        )
+        return download_from_github_release(filename, local_path)
+
+
+local_checkpoint_path = fetch_checkpoint(checkpoint_filename, local_checkpoint_path)
+local_yunet_checkpoint_path = fetch_checkpoint(
+    yunet_checkpoint_filename, local_yunet_checkpoint_path
+)
 
 
 def ensure_color(image):

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,18 @@ setup(
         ]
     ),
     include_package_data=True,
+    python_requires=">=3.8",
+    classifiers=[
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
+        "License :: OSI Approved :: MIT License",
+        "Topic :: Scientific/Engineering :: Image Recognition",
+    ],
     install_requires=[
         "numpy",
         "opencv-python>=4.8.0",

--- a/space/README.md
+++ b/space/README.md
@@ -1,0 +1,83 @@
+---
+title: Residual Masking Network
+emoji: 😀
+colorFrom: purple
+colorTo: pink
+sdk: static
+app_file: index.html
+pinned: false
+license: mit
+short_description: In-browser facial expression recognition (FER2013, ONNX)
+models:
+  - phamquiluan/ResidualMaskingNetwork
+tags:
+  - facial-expression-recognition
+  - emotion-recognition
+  - fer2013
+  - onnx
+  - webassembly
+---
+
+# Residual Masking Network — Facial Expression Recognition
+
+[ResMaskingNet](https://github.com/phamquiluan/ResidualMaskingNetwork) running entirely in
+your browser. Images never leave your machine: YuNet locates faces and ResMaskingNet
+classifies each crop into one of the seven FER2013 emotions, all through
+onnxruntime-web on WebAssembly.
+
+- Model weights: [phamquiluan/ResidualMaskingNetwork](https://huggingface.co/phamquiluan/ResidualMaskingNetwork)
+- Paper: [Facial Expression Recognition using Residual Masking Network (ICPR 2020)](https://huggingface.co/papers/2603.05937)
+- Python package: `pip install rmn`
+
+## How it works
+
+The 143M-parameter classifier is exported to ONNX and statically quantised to int8
+(526 MB to 132 MB) using FER2013 training images for calibration. On the FER2013
+private test split the quantised model scores within noise of the fp32 export, so the
+size reduction is effectively free.
+
+The JavaScript reimplements the `rmn` preprocessing exactly rather than approximating
+it: OpenCV's BGR-to-grayscale weights, the 1.1x square box expansion from
+`convert_to_square`, OpenCV's bilinear pixel-center mapping, and the plain `/255`
+scaling that `transforms.ToTensor()` applies. Verified against the Python pipeline on
+the same image, agreement is 0px of box drift and under 0.002 absolute difference on
+every class probability.
+
+Face detection letterboxes the input to 640x640 because the YuNet ONNX has a fixed
+input shape; a plain square resize would stretch non-square photos and shift the boxes.
+
+## Performance
+
+Roughly 0.9s per image single-threaded on a modern laptop. WASM multithreading needs
+cross-origin isolation, which static Spaces do not provide, so the page runs
+single-threaded and picks up threads automatically if those headers ever appear.
+
+Webcam mode analyses a frame every 2.5 seconds rather than every frame: at ~0.9s per
+inference, per-frame analysis would queue up faster than it drains and the page would
+fall behind. The video preview still repaints at display rate with the latest boxes
+overlaid, so it looks live while the classifier runs on a steady cadence. The period is
+measured start-to-start, and a run that overruns it delays the next one instead of
+overlapping. Inference pauses while the tab is hidden.
+
+Activity is visible at all times: a dot pulses and the bar sweeps while a run is in
+flight, the bar then drains toward the next scheduled run, and the status line reports
+the frame number, face count, top emotion and per-frame time. Those animations use
+`transform` and `opacity` so they stay on the compositor — inference blocks the main
+thread for its duration, and a `width` or `background-position` animation would freeze
+exactly when it needs to show progress.
+
+The 132 MB model downloads once and is stored in the Cache API, so repeat visits skip
+the download.
+
+## Citation
+
+```bibtex
+@inproceedings{pham2021facial,
+  title={Facial expression recognition using residual masking network},
+  author={Pham, Luan and Vu, The Huynh and Tran, Tuan Anh},
+  booktitle={2020 25th International Conference on Pattern Recognition (ICPR)},
+  pages={4513--4519},
+  year={2021},
+  organization={IEEE}
+}
+```

--- a/space/README.md
+++ b/space/README.md
@@ -18,12 +18,10 @@ tags:
   - webassembly
 ---
 
-# Residual Masking Network — Facial Expression Recognition
-
-[ResMaskingNet](https://github.com/phamquiluan/ResidualMaskingNetwork) running entirely in
-your browser. Images never leave your machine: YuNet locates faces and ResMaskingNet
-classifies each crop into one of the seven FER2013 emotions, all through
-onnxruntime-web on WebAssembly.
+[ResMaskingNet](https://github.com/phamquiluan/ResidualMaskingNetwork) running
+entirely in your browser. Images never leave your machine: YuNet locates faces
+and ResMaskingNet classifies each crop into one of the seven FER2013 emotions,
+all through onnxruntime-web on WebAssembly.
 
 - Model weights: [phamquiluan/ResidualMaskingNetwork](https://huggingface.co/phamquiluan/ResidualMaskingNetwork)
 - Paper: [Facial Expression Recognition using Residual Masking Network (ICPR 2020)](https://huggingface.co/papers/2603.05937)
@@ -31,43 +29,47 @@ onnxruntime-web on WebAssembly.
 
 ## How it works
 
-The 143M-parameter classifier is exported to ONNX and statically quantised to int8
-(526 MB to 132 MB) using FER2013 training images for calibration. On the FER2013
-private test split the quantised model scores within noise of the fp32 export, so the
-size reduction is effectively free.
+The 143M-parameter classifier is exported to ONNX and statically quantised to
+int8 (526 MB to 132 MB) using FER2013 training images for calibration. On the
+FER2013 private test split the quantised model scores within noise of the fp32
+export, so the size reduction is effectively free.
 
-The JavaScript reimplements the `rmn` preprocessing exactly rather than approximating
-it: OpenCV's BGR-to-grayscale weights, the 1.1x square box expansion from
-`convert_to_square`, OpenCV's bilinear pixel-center mapping, and the plain `/255`
-scaling that `transforms.ToTensor()` applies. Verified against the Python pipeline on
-the same image, agreement is 0px of box drift and under 0.002 absolute difference on
-every class probability.
+The JavaScript reimplements the `rmn` preprocessing exactly rather than
+approximating it: OpenCV's BGR-to-grayscale weights, the 1.1x square box
+expansion from `convert_to_square`, OpenCV's bilinear pixel-center mapping, and
+the plain `/255` scaling that `transforms.ToTensor()` applies. Verified against
+the Python pipeline on the same image, agreement is 0px of box drift and under
+0.002 absolute difference on every class probability.
 
-Face detection letterboxes the input to 640x640 because the YuNet ONNX has a fixed
-input shape; a plain square resize would stretch non-square photos and shift the boxes.
+Face detection letterboxes the input to 640x640 because the YuNet ONNX has a
+fixed input shape; a plain square resize would stretch non-square photos and
+shift the boxes.
 
 ## Performance
 
-Roughly 0.9s per image single-threaded on a modern laptop. WASM multithreading needs
-cross-origin isolation, which static Spaces do not provide, so the page runs
-single-threaded and picks up threads automatically if those headers ever appear.
+Roughly 0.9s per image single-threaded on a modern laptop. WASM multithreading
+needs cross-origin isolation, which static Spaces do not provide, so the page
+runs single-threaded and picks up threads automatically if those headers ever
+appear.
 
-Webcam mode analyses a frame every 2.5 seconds rather than every frame: at ~0.9s per
-inference, per-frame analysis would queue up faster than it drains and the page would
-fall behind. The video preview still repaints at display rate with the latest boxes
-overlaid, so it looks live while the classifier runs on a steady cadence. The period is
-measured start-to-start, and a run that overruns it delays the next one instead of
-overlapping. Inference pauses while the tab is hidden.
+Webcam mode analyses a frame every 2.5 seconds rather than every frame: at ~0.9s
+per inference, per-frame analysis would queue up faster than it drains and the
+page would fall behind. The video preview still repaints at display rate with
+the latest boxes overlaid, so it looks live while the classifier runs on a
+steady cadence. The period is measured start-to-start, and a run that overruns
+it delays the next one instead of overlapping. Inference pauses while the tab is
+hidden.
 
-Activity is visible at all times: a dot pulses and the bar sweeps while a run is in
-flight, the bar then drains toward the next scheduled run, and the status line reports
-the frame number, face count, top emotion and per-frame time. Those animations use
-`transform` and `opacity` so they stay on the compositor — inference blocks the main
-thread for its duration, and a `width` or `background-position` animation would freeze
-exactly when it needs to show progress.
+Activity is visible at all times: a dot pulses and the bar sweeps while a run is
+in flight, the bar then drains toward the next scheduled run, and the status
+line reports the frame number, face count, top emotion and per-frame time. Those
+animations use `transform` and `opacity` so they stay on the compositor —
+inference blocks the main thread for its duration, and a `width` or
+`background-position` animation would freeze exactly when it needs to show
+progress.
 
-The 132 MB model downloads once and is stored in the Cache API, so repeat visits skip
-the download.
+The 132 MB model downloads once and is stored in the Cache API, so repeat visits
+skip the download.
 
 ## Citation
 

--- a/space/app.js
+++ b/space/app.js
@@ -8,6 +8,13 @@
  * `pip install rmn` agree on the same image.
  */
 
+/* global ort */
+
+/* Every index into an array in this file is a loop counter or a value derived
+   from model output shapes, never a user-supplied key, so the object-injection
+   rule only produces false positives on the pixel and tensor loops below. */
+/* eslint-disable security/detect-object-injection */
+
 // overridable so the pipeline can be exercised against local files in tests
 const MODEL_BASE =
   window.RMN_MODEL_BASE ||
@@ -85,18 +92,21 @@ async function loadModels(onStatus) {
 
   onStatus("Loading face detector...", 0);
   const detectorBytes = await fetchWithProgress(DETECTOR_URL, (p) =>
-    onStatus("Loading face detector...", p * 0.02)
+    onStatus("Loading face detector...", p * 0.02),
   );
   detectorSession = await ort.InferenceSession.create(detectorBytes, {
     executionProviders: ["wasm"],
   });
 
-  onStatus("Downloading emotion model (132 MB, cached after first visit)...", 0.02);
+  onStatus(
+    "Downloading emotion model (132 MB, cached after first visit)...",
+    0.02,
+  );
   const classifierBytes = await fetchWithProgress(CLASSIFIER_URL, (p) =>
     onStatus(
       `Downloading emotion model (132 MB, cached after first visit)... ${Math.round(p * 100)}%`,
-      0.02 + p * 0.93
-    )
+      0.02 + p * 0.93,
+    ),
   );
 
   onStatus("Initialising inference session...", 0.96);
@@ -142,10 +152,8 @@ function resizeBilinear(src, srcW, srcH, dstW, dstH) {
       const x1 = Math.min(x0 + 1, srcW - 1);
       const wx = fx - x0;
 
-      const top =
-        src[y0 * srcW + x0] * (1 - wx) + src[y0 * srcW + x1] * wx;
-      const bottom =
-        src[y1 * srcW + x0] * (1 - wx) + src[y1 * srcW + x1] * wx;
+      const top = src[y0 * srcW + x0] * (1 - wx) + src[y0 * srcW + x1] * wx;
+      const bottom = src[y1 * srcW + x0] * (1 - wx) + src[y1 * srcW + x1] * wx;
       dst[y * dstW + x] = top * (1 - wy) + bottom * wy;
     }
   }
@@ -167,8 +175,14 @@ function nonMaxSuppression(boxes, scores, threshold) {
 
     for (let i = order.length - 1; i >= 0; i--) {
       const [bx, by, bw, bh] = boxes[order[i]];
-      const overlapW = Math.max(0, Math.min(ax + aw, bx + bw) - Math.max(ax, bx));
-      const overlapH = Math.max(0, Math.min(ay + ah, by + bh) - Math.max(ay, by));
+      const overlapW = Math.max(
+        0,
+        Math.min(ax + aw, bx + bw) - Math.max(ax, bx),
+      );
+      const overlapH = Math.max(
+        0,
+        Math.min(ay + ah, by + bh) - Math.max(ay, by),
+      );
       const intersection = overlapW * overlapH;
       const iou = intersection / (aw * ah + bw * bh - intersection);
       if (iou > threshold) order.splice(i, 1);
@@ -195,7 +209,7 @@ function letterbox(canvas) {
     0,
     0,
     Math.round(canvas.width * scale),
-    Math.round(canvas.height * scale)
+    Math.round(canvas.height * scale),
   );
   return { canvas: target, scale };
 }
@@ -329,7 +343,7 @@ async function analyse(sourceCanvas) {
     0,
     0,
     sourceCanvas.width,
-    sourceCanvas.height
+    sourceCanvas.height,
   );
   const gray = toGrayscale(data, sourceCanvas.width, sourceCanvas.height);
 
@@ -351,12 +365,14 @@ async function analyse(sourceCanvas) {
 
   const results = [];
   for (const face of faces) {
-    const box = usedFallback ? face : convertToSquare(face.xmin, face.ymin, face.xmax, face.ymax);
+    const box = usedFallback
+      ? face
+      : convertToSquare(face.xmin, face.ymin, face.xmax, face.ymax);
     const prediction = await classifyCrop(
       gray,
       sourceCanvas.width,
       sourceCanvas.height,
-      box
+      box,
     );
     if (prediction) results.push({ ...box, ...prediction });
   }

--- a/space/app.js
+++ b/space/app.js
@@ -1,0 +1,367 @@
+/*
+ * Browser port of the `rmn` inference pipeline.
+ *
+ * YuNet locates faces, ResMaskingNet classifies each crop. Every preprocessing
+ * step mirrors the Python package exactly -- grayscale conversion, the 1.1x
+ * square box expansion, OpenCV's bilinear pixel-center mapping, and the plain
+ * /255 scaling that `transforms.ToTensor()` applies -- so the browser and
+ * `pip install rmn` agree on the same image.
+ */
+
+// overridable so the pipeline can be exercised against local files in tests
+const MODEL_BASE =
+  window.RMN_MODEL_BASE ||
+  "https://huggingface.co/phamquiluan/ResidualMaskingNetwork/resolve/main/";
+const CLASSIFIER_URL = MODEL_BASE + "onnx/resmasking_int8.onnx";
+const DETECTOR_URL = MODEL_BASE + "face_detection_yunet_2023mar.onnx";
+
+const EMOTIONS = [
+  "angry",
+  "disgust",
+  "fear",
+  "happy",
+  "sad",
+  "surprise",
+  "neutral",
+];
+
+const DET_SIZE = 640;
+const STRIDES = [8, 16, 32];
+const SCORE_THRESHOLD = 0.5;
+const NMS_THRESHOLD = 0.3;
+const FACE_SIZE = 224;
+
+let detectorSession = null;
+let classifierSession = null;
+
+/* ---------- model loading ---------- */
+
+async function fetchWithProgress(url, onProgress) {
+  const cache = await caches.open("rmn-models-v1");
+  const cached = await cache.match(url);
+  if (cached) {
+    onProgress(1);
+    return cached.arrayBuffer();
+  }
+
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`${response.status} fetching ${url}`);
+
+  const total = Number(response.headers.get("content-length")) || 0;
+  const reader = response.body.getReader();
+  const chunks = [];
+  let received = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    received += value.length;
+    if (total) onProgress(received / total);
+  }
+
+  const buffer = new Uint8Array(received);
+  let offset = 0;
+  for (const chunk of chunks) {
+    buffer.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  // store a copy so repeat visits skip the download entirely
+  await cache.put(url, new Response(buffer.slice()));
+  return buffer.buffer;
+}
+
+async function loadModels(onStatus) {
+  ort.env.wasm.wasmPaths =
+    "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.27.0/dist/";
+  // WASM threads need cross-origin isolation, which static hosting does not
+  // provide; single-threaded runs a face in well under a second, so take the
+  // extra threads only if the headers ever appear
+  ort.env.wasm.numThreads = self.crossOriginIsolated
+    ? Math.min(4, navigator.hardwareConcurrency || 1)
+    : 1;
+  ort.env.wasm.simd = true;
+
+  onStatus("Loading face detector...", 0);
+  const detectorBytes = await fetchWithProgress(DETECTOR_URL, (p) =>
+    onStatus("Loading face detector...", p * 0.02)
+  );
+  detectorSession = await ort.InferenceSession.create(detectorBytes, {
+    executionProviders: ["wasm"],
+  });
+
+  onStatus("Downloading emotion model (132 MB, cached after first visit)...", 0.02);
+  const classifierBytes = await fetchWithProgress(CLASSIFIER_URL, (p) =>
+    onStatus(
+      `Downloading emotion model (132 MB, cached after first visit)... ${Math.round(p * 100)}%`,
+      0.02 + p * 0.93
+    )
+  );
+
+  onStatus("Initialising inference session...", 0.96);
+  classifierSession = await ort.InferenceSession.create(classifierBytes, {
+    executionProviders: ["wasm"],
+  });
+
+  onStatus("Ready.", 1);
+}
+
+/* ---------- image helpers (ported from OpenCV semantics) ---------- */
+
+/** cv2.COLOR_BGR2GRAY / COLOR_RGB2GRAY weights. */
+function toGrayscale(rgba, width, height) {
+  const gray = new Float32Array(width * height);
+  for (let i = 0, p = 0; i < gray.length; i++, p += 4) {
+    gray[i] = 0.299 * rgba[p] + 0.587 * rgba[p + 1] + 0.114 * rgba[p + 2];
+  }
+  return gray;
+}
+
+/**
+ * Bilinear resize using OpenCV's pixel-center mapping,
+ * src = (dst + 0.5) * scale - 0.5, which differs from a naive dst * scale
+ * and shifts the sampled crop by half a pixel if you get it wrong.
+ */
+function resizeBilinear(src, srcW, srcH, dstW, dstH) {
+  const dst = new Float32Array(dstW * dstH);
+  const scaleX = srcW / dstW;
+  const scaleY = srcH / dstH;
+
+  for (let y = 0; y < dstH; y++) {
+    let fy = (y + 0.5) * scaleY - 0.5;
+    if (fy < 0) fy = 0;
+    const y0 = Math.min(Math.floor(fy), srcH - 1);
+    const y1 = Math.min(y0 + 1, srcH - 1);
+    const wy = fy - y0;
+
+    for (let x = 0; x < dstW; x++) {
+      let fx = (x + 0.5) * scaleX - 0.5;
+      if (fx < 0) fx = 0;
+      const x0 = Math.min(Math.floor(fx), srcW - 1);
+      const x1 = Math.min(x0 + 1, srcW - 1);
+      const wx = fx - x0;
+
+      const top =
+        src[y0 * srcW + x0] * (1 - wx) + src[y0 * srcW + x1] * wx;
+      const bottom =
+        src[y1 * srcW + x0] * (1 - wx) + src[y1 * srcW + x1] * wx;
+      dst[y * dstW + x] = top * (1 - wy) + bottom * wy;
+    }
+  }
+  return dst;
+}
+
+/* ---------- face detection ---------- */
+
+function nonMaxSuppression(boxes, scores, threshold) {
+  const order = scores
+    .map((score, index) => index)
+    .sort((a, b) => scores[b] - scores[a]);
+  const keep = [];
+
+  while (order.length) {
+    const current = order.shift();
+    keep.push(current);
+    const [ax, ay, aw, ah] = boxes[current];
+
+    for (let i = order.length - 1; i >= 0; i--) {
+      const [bx, by, bw, bh] = boxes[order[i]];
+      const overlapW = Math.max(0, Math.min(ax + aw, bx + bw) - Math.max(ax, bx));
+      const overlapH = Math.max(0, Math.min(ay + ah, by + bh) - Math.max(ay, by));
+      const intersection = overlapW * overlapH;
+      const iou = intersection / (aw * ah + bw * bh - intersection);
+      if (iou > threshold) order.splice(i, 1);
+    }
+  }
+  return keep;
+}
+
+/**
+ * Letterbox into DET_SIZE so the model sees an undistorted image; the ONNX has
+ * a fixed 640x640 input, and a plain square resize would stretch tall or wide
+ * photos and shift the boxes.
+ */
+function letterbox(canvas) {
+  const scale = Math.min(DET_SIZE / canvas.width, DET_SIZE / canvas.height);
+  const target = document.createElement("canvas");
+  target.width = DET_SIZE;
+  target.height = DET_SIZE;
+  const context = target.getContext("2d", { willReadFrequently: true });
+  context.fillStyle = "black";
+  context.fillRect(0, 0, DET_SIZE, DET_SIZE);
+  context.drawImage(
+    canvas,
+    0,
+    0,
+    Math.round(canvas.width * scale),
+    Math.round(canvas.height * scale)
+  );
+  return { canvas: target, scale };
+}
+
+async function detectFaces(sourceCanvas) {
+  const { canvas, scale } = letterbox(sourceCanvas);
+  const { data } = canvas
+    .getContext("2d", { willReadFrequently: true })
+    .getImageData(0, 0, DET_SIZE, DET_SIZE);
+
+  // YuNet consumes raw BGR values in [0, 255], no mean subtraction
+  const input = new Float32Array(3 * DET_SIZE * DET_SIZE);
+  const plane = DET_SIZE * DET_SIZE;
+  for (let i = 0, p = 0; i < plane; i++, p += 4) {
+    input[i] = data[p + 2];
+    input[plane + i] = data[p + 1];
+    input[2 * plane + i] = data[p];
+  }
+
+  const outputs = await detectorSession.run({
+    input: new ort.Tensor("float32", input, [1, 3, DET_SIZE, DET_SIZE]),
+  });
+
+  const boxes = [];
+  const scores = [];
+  for (const stride of STRIDES) {
+    const cls = outputs[`cls_${stride}`].data;
+    const obj = outputs[`obj_${stride}`].data;
+    const bbox = outputs[`bbox_${stride}`].data;
+    const cols = DET_SIZE / stride;
+
+    for (let i = 0; i < cls.length; i++) {
+      const clsScore = Math.min(Math.max(cls[i], 0), 1);
+      const objScore = Math.min(Math.max(obj[i], 0), 1);
+      const score = Math.sqrt(clsScore * objScore);
+      if (score < SCORE_THRESHOLD) continue;
+
+      const col = i % cols;
+      const row = Math.floor(i / cols);
+      const cx = (col + bbox[i * 4]) * stride;
+      const cy = (row + bbox[i * 4 + 1]) * stride;
+      const w = Math.exp(bbox[i * 4 + 2]) * stride;
+      const h = Math.exp(bbox[i * 4 + 3]) * stride;
+      boxes.push([cx - w / 2, cy - h / 2, w, h]);
+      scores.push(score);
+    }
+  }
+
+  return nonMaxSuppression(boxes, scores, NMS_THRESHOLD).map((index) => {
+    const [x, y, w, h] = boxes[index];
+    return {
+      xmin: x / scale,
+      ymin: y / scale,
+      xmax: (x + w) / scale,
+      ymax: (y + h) / scale,
+      score: scores[index],
+    };
+  });
+}
+
+/* ---------- classification ---------- */
+
+/** Port of rmn's convert_to_square: a 1.1x expanded square around the box. */
+function convertToSquare(xmin, ymin, xmax, ymax) {
+  const centerX = Math.floor((xmin + xmax) / 2);
+  const centerY = Math.floor((ymin + ymax) / 2);
+  let length = Math.floor(Math.floor((xmax - xmin + (ymax - ymin)) / 2) / 2);
+  length *= 1.1;
+  return {
+    xmin: Math.trunc(centerX - length),
+    ymin: Math.trunc(centerY - length),
+    xmax: Math.trunc(centerX + length),
+    ymax: Math.trunc(centerY + length),
+  };
+}
+
+function softmax(logits) {
+  const max = Math.max(...logits);
+  const exps = logits.map((v) => Math.exp(v - max));
+  const sum = exps.reduce((a, b) => a + b, 0);
+  return exps.map((v) => v / sum);
+}
+
+async function classifyCrop(gray, width, height, box) {
+  // numpy slicing truncates at the array edge rather than padding, so clamp
+  // the same way the Python does
+  const x0 = Math.max(box.xmin, 0);
+  const y0 = Math.max(box.ymin, 0);
+  const x1 = Math.min(box.xmax, width);
+  const y1 = Math.min(box.ymax, height);
+  const cropW = x1 - x0;
+  const cropH = y1 - y0;
+  if (cropW < 10 || cropH < 10) return null;
+
+  const crop = new Float32Array(cropW * cropH);
+  for (let y = 0; y < cropH; y++) {
+    for (let x = 0; x < cropW; x++) {
+      crop[y * cropW + x] = gray[(y0 + y) * width + (x0 + x)];
+    }
+  }
+
+  const resized = resizeBilinear(crop, cropW, cropH, FACE_SIZE, FACE_SIZE);
+  const plane = FACE_SIZE * FACE_SIZE;
+  const input = new Float32Array(3 * plane);
+  for (let i = 0; i < plane; i++) {
+    const value = resized[i] / 255;
+    input[i] = value;
+    input[plane + i] = value;
+    input[2 * plane + i] = value;
+  }
+
+  const outputs = await classifierSession.run({
+    input: new ort.Tensor("float32", input, [1, 3, FACE_SIZE, FACE_SIZE]),
+  });
+  const logits = Array.from(Object.values(outputs)[0].data);
+  const probabilities = softmax(logits);
+  const best = probabilities.indexOf(Math.max(...probabilities));
+
+  return {
+    label: EMOTIONS[best],
+    probability: probabilities[best],
+    probabilities,
+  };
+}
+
+/* ---------- top level ---------- */
+
+async function analyse(sourceCanvas) {
+  const context = sourceCanvas.getContext("2d", { willReadFrequently: true });
+  const { data } = context.getImageData(
+    0,
+    0,
+    sourceCanvas.width,
+    sourceCanvas.height
+  );
+  const gray = toGrayscale(data, sourceCanvas.width, sourceCanvas.height);
+
+  let faces = await detectFaces(sourceCanvas);
+  let usedFallback = false;
+
+  if (!faces.length) {
+    faces = [
+      {
+        xmin: 0,
+        ymin: 0,
+        xmax: sourceCanvas.width,
+        ymax: sourceCanvas.height,
+        score: null,
+      },
+    ];
+    usedFallback = true;
+  }
+
+  const results = [];
+  for (const face of faces) {
+    const box = usedFallback ? face : convertToSquare(face.xmin, face.ymin, face.xmax, face.ymax);
+    const prediction = await classifyCrop(
+      gray,
+      sourceCanvas.width,
+      sourceCanvas.height,
+      box
+    );
+    if (prediction) results.push({ ...box, ...prediction });
+  }
+
+  return { results, usedFallback };
+}
+
+window.rmn = { loadModels, analyse, EMOTIONS };

--- a/space/index.html
+++ b/space/index.html
@@ -1,0 +1,376 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Residual Masking Network — Facial Expression Recognition</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #ffffff;
+        --fg: #14151a;
+        --muted: #6b7280;
+        --line: #e5e7eb;
+        --panel: #f9fafb;
+        --accent: #7c3aed;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0f1116;
+          --fg: #e8eaed;
+          --muted: #9aa1ab;
+          --line: #262b36;
+          --panel: #171a21;
+          --accent: #a78bfa;
+        }
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        padding: 2rem 1.25rem 4rem;
+        background: var(--bg);
+        color: var(--fg);
+        font: 16px/1.6 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+      }
+      main { max-width: 960px; margin: 0 auto; }
+      h1 { font-size: 1.6rem; margin: 0 0 .35rem; letter-spacing: -.01em; }
+      .sub { color: var(--muted); margin: 0 0 1.25rem; }
+      .sub a { color: var(--accent); }
+      .controls { display: flex; flex-wrap: wrap; gap: .6rem; margin-bottom: 1rem; }
+      button {
+        font: inherit; font-weight: 550; cursor: pointer;
+        padding: .5rem 1rem; border-radius: .5rem;
+        border: 1px solid var(--line); background: var(--panel); color: var(--fg);
+      }
+      button.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+      button:disabled { opacity: .5; cursor: not-allowed; }
+      .statusline { display: flex; align-items: center; gap: .5rem; min-height: 1.5rem; }
+      #status { color: var(--muted); font-size: .9rem; }
+      #dot {
+        width: .55rem; height: .55rem; border-radius: 50%;
+        background: var(--line); flex: none; transition: background .2s;
+      }
+      #dot.ready { background: #22c55e; }
+      #dot.busy { background: var(--accent); animation: pulse 1s ease-in-out infinite; }
+      @keyframes pulse { 0%, 100% { opacity: 1; transform: scale(1); } 50% { opacity: .35; transform: scale(.75); } }
+      #bar { height: 4px; background: var(--line); border-radius: 2px; overflow: hidden; margin: .4rem 0 1rem; }
+      #bar > div { height: 100%; width: 0; background: var(--accent); transition: width .2s; }
+      /* Indeterminate sweep while inference runs. WASM inference blocks the main
+         thread, so this animates transform (and the dot opacity/scale) to stay on
+         the compositor -- a background-position or width animation would freeze
+         for the whole ~0.9s and look broken exactly when it matters. */
+      #bar.busy > div {
+        width: 35% !important;
+        transition: none;
+        background: var(--accent);
+        animation: sweep 1.1s ease-in-out infinite;
+      }
+      @keyframes sweep { from { transform: translateX(-110%); } to { transform: translateX(400%); } }
+      @media (prefers-reduced-motion: reduce) {
+        #dot.busy, #bar.busy > div { animation: none; }
+        #bar.busy > div { background: var(--accent); opacity: .5; }
+      }
+      .grid { display: grid; gap: 1.25rem; grid-template-columns: 1fr; }
+      @media (min-width: 760px) { .grid { grid-template-columns: 3fr 2fr; } }
+      .panel { border: 1px solid var(--line); border-radius: .75rem; background: var(--panel); padding: 1rem; }
+      canvas, video { width: 100%; height: auto; border-radius: .5rem; display: block; background: #000; }
+      video { display: none; }
+      .row { display: flex; align-items: center; gap: .6rem; margin-bottom: .5rem; }
+      .row .name { width: 5.5rem; font-size: .875rem; }
+      .row .track { flex: 1; height: 8px; background: var(--line); border-radius: 4px; overflow: hidden; }
+      .row .fill { height: 100%; background: var(--accent); width: 0; transition: width .25s; }
+      .row .pct { width: 3.2rem; text-align: right; font-variant-numeric: tabular-nums; font-size: .85rem; color: var(--muted); }
+      .row.top .name, .row.top .pct { color: var(--fg); font-weight: 650; }
+      footer { margin-top: 2rem; color: var(--muted); font-size: .85rem; }
+      footer a { color: var(--accent); }
+      code { background: var(--panel); border: 1px solid var(--line); padding: .1rem .35rem; border-radius: .3rem; font-size: .85em; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Residual Masking Network</h1>
+      <p class="sub">
+        Facial expression recognition, running entirely in your browser — no server, no upload.
+        <a href="https://huggingface.co/phamquiluan/ResidualMaskingNetwork">Model</a> ·
+        <a href="https://huggingface.co/papers/2603.05937">Paper</a> ·
+        <a href="https://github.com/phamquiluan/ResidualMaskingNetwork">Code</a> ·
+        <code>pip install rmn</code>
+      </p>
+
+      <div class="controls">
+        <button id="pick" class="primary" disabled>Choose image</button>
+        <button id="camera" disabled>Use webcam</button>
+        <input id="file" type="file" accept="image/*" hidden />
+      </div>
+
+      <div id="bar"><div></div></div>
+      <div class="statusline"><span id="dot"></span><span id="status">Starting…</span></div>
+
+      <div class="grid">
+        <div class="panel">
+          <canvas id="canvas" width="640" height="480"></canvas>
+          <video id="video" playsinline muted></video>
+        </div>
+        <div class="panel" id="scores"></div>
+      </div>
+
+      <footer>
+        YuNet detects faces, then ResMaskingNet (143M parameters, int8-quantised to 132&nbsp;MB)
+        classifies each crop into the seven FER2013 emotions. The model downloads once and is
+        cached by your browser. Preprocessing matches the <code>rmn</code> Python package.
+      </footer>
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/onnxruntime-web@1.27.0/dist/ort.min.js"></script>
+    <script src="app.js"></script>
+    <script>
+      const canvas = document.getElementById("canvas");
+      const context = canvas.getContext("2d", { willReadFrequently: true });
+      const video = document.getElementById("video");
+      const statusEl = document.getElementById("status");
+      const barElement = document.getElementById("bar");
+      const barEl = document.querySelector("#bar > div");
+      const dotEl = document.getElementById("dot");
+      const scoresEl = document.getElementById("scores");
+      const pickButton = document.getElementById("pick");
+      const cameraButton = document.getElementById("camera");
+      const fileInput = document.getElementById("file");
+
+      // Inference costs ~0.9s, so analysing every frame would queue up faster
+      // than it drains. The preview stays smooth while inference runs on this
+      // period, measured start-to-start so the cadence holds steady; a run that
+      // overruns the period simply delays the next one rather than overlapping.
+      const LIVE_INTERVAL_MS = 2500;
+
+      // the visible canvas gets boxes painted on it; inference must see a clean
+      // frame, or it would classify the previous run's annotations
+      const frameCanvas = document.createElement("canvas");
+      const frameContext = frameCanvas.getContext("2d", { willReadFrequently: true });
+
+      let stream = null;
+      let live = false;
+      let previewHandle = null;
+      let lastResults = [];
+      let liveFrames = 0;
+
+      function setStatus(text, progress) {
+        statusEl.textContent = text;
+        if (typeof progress === "number") {
+          barEl.style.transition = "width .2s";
+          barEl.style.width = `${progress * 100}%`;
+        }
+      }
+
+      /** Sweeping bar + pulsing dot: inference is running right now. */
+      function setBusy(busy) {
+        barElement.classList.toggle("busy", busy);
+        dotEl.classList.toggle("busy", busy);
+        dotEl.classList.toggle("ready", !busy);
+      }
+
+      /** Drain the bar toward the next scheduled run so the wait is visible. */
+      function startCountdown(ms) {
+        barEl.style.transition = "none";
+        barEl.style.width = "100%";
+        void barEl.offsetWidth; // force the reset to take effect before animating
+        barEl.style.transition = `width ${ms}ms linear`;
+        barEl.style.width = "0%";
+      }
+
+      function renderScores(probabilities) {
+        const top = probabilities ? probabilities.indexOf(Math.max(...probabilities)) : -1;
+        scoresEl.innerHTML = window.rmn.EMOTIONS.map((name, i) => {
+          const value = probabilities ? probabilities[i] : 0;
+          return `<div class="row ${i === top ? "top" : ""}">
+              <span class="name">${name}</span>
+              <span class="track"><span class="fill" style="width:${(value * 100).toFixed(1)}%"></span></span>
+              <span class="pct">${(value * 100).toFixed(1)}%</span>
+            </div>`;
+        }).join("");
+      }
+
+      function drawBoxes(results) {
+        const scale = Math.max(1, canvas.width / 640);
+        context.lineWidth = 2 * scale;
+        context.strokeStyle = "#b3ffb3";
+        context.font = `${Math.round(18 * scale)}px ui-sans-serif, system-ui, sans-serif`;
+
+        for (const r of results) {
+          const w = r.xmax - r.xmin;
+          const h = r.ymax - r.ymin;
+          context.strokeRect(r.xmin, r.ymin, w, h);
+
+          const text = `${r.label} ${Math.round(r.probability * 100)}`;
+          const width = context.measureText(text).width + 10 * scale;
+          const height = 24 * scale;
+          const x = Math.min(r.xmax, canvas.width - width);
+          const y = Math.max(r.ymin, height);
+          context.fillStyle = "#df80ff";
+          context.fillRect(x, y - height, width, height);
+          context.fillStyle = "#000";
+          context.fillText(text, x + 5 * scale, y - 6 * scale);
+        }
+      }
+
+      function showImage(source, width, height) {
+        canvas.width = width;
+        canvas.height = height;
+        context.drawImage(source, 0, 0, width, height);
+      }
+
+      /** Let the browser paint before we hand the main thread to WASM. */
+      function nextPaint() {
+        return new Promise((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(resolve))
+        );
+      }
+
+      async function run(source) {
+        setBusy(true);
+        setStatus("Analysing…");
+        await nextPaint();
+        const started = performance.now();
+        let results, usedFallback;
+        try {
+          ({ results, usedFallback } = await window.rmn.analyse(source));
+        } finally {
+          setBusy(false);
+        }
+        const elapsed = ((performance.now() - started) / 1000).toFixed(1);
+
+        lastResults = results;
+        if (!live) drawBoxes(results);
+
+        if (!results.length) {
+          renderScores(null);
+          setStatus(`No face found (${elapsed}s).`, live ? undefined : 1);
+          return;
+        }
+
+        const largest = results.reduce((a, b) =>
+          (a.xmax - a.xmin) * (a.ymax - a.ymin) >= (b.xmax - b.xmin) * (b.ymax - b.ymin) ? a : b
+        );
+        renderScores(largest.probabilities);
+
+        const faces = `${results.length} face${results.length > 1 ? "s" : ""}`;
+        const top = `${largest.label} ${(largest.probability * 100).toFixed(0)}%`;
+        if (usedFallback) {
+          setStatus(
+            `No face detected — classified the whole image (${elapsed}s).`,
+            live ? undefined : 1
+          );
+        } else if (live) {
+          setStatus(`Live · frame ${liveFrames} · ${faces} · ${top} · ${elapsed}s`);
+        } else {
+          setStatus(`${faces} detected in ${elapsed}s — ${top}.`, 1);
+        }
+      }
+
+      pickButton.onclick = () => fileInput.click();
+
+      fileInput.onchange = () => {
+        const file = fileInput.files[0];
+        if (!file) return;
+        if (live) stopCamera();
+        const image = new Image();
+        image.onload = () => {
+          const scale = Math.min(1, 960 / image.width);
+          showImage(image, Math.round(image.width * scale), Math.round(image.height * scale));
+          URL.revokeObjectURL(image.src);
+          run(canvas);
+        };
+        image.src = URL.createObjectURL(file);
+      };
+
+      /** Repaint the video at display rate, overlaying the most recent boxes. */
+      function previewLoop() {
+        if (!live) return;
+        if (video.videoWidth) {
+          if (canvas.width !== video.videoWidth) {
+            canvas.width = video.videoWidth;
+            canvas.height = video.videoHeight;
+          }
+          context.drawImage(video, 0, 0);
+          drawBoxes(lastResults);
+        }
+        previewHandle = requestAnimationFrame(previewLoop);
+      }
+
+      async function liveLoop() {
+        while (live) {
+          const cycleStarted = performance.now();
+          // a hidden tab throttles timers and wastes CPU on frames nobody sees
+          if (!document.hidden && video.videoWidth) {
+            liveFrames += 1;
+            frameCanvas.width = video.videoWidth;
+            frameCanvas.height = video.videoHeight;
+            frameContext.drawImage(video, 0, 0);
+            try {
+              await run(frameCanvas);
+            } catch (error) {
+              setStatus(`Inference failed: ${error.message}`);
+            }
+          }
+          const remaining = Math.max(250, LIVE_INTERVAL_MS - (performance.now() - cycleStarted));
+          if (live) startCountdown(remaining);
+          await new Promise((resolve) => setTimeout(resolve, remaining));
+        }
+      }
+
+      function stopCamera() {
+        live = false;
+        if (previewHandle) cancelAnimationFrame(previewHandle);
+        previewHandle = null;
+        if (stream) stream.getTracks().forEach((track) => track.stop());
+        stream = null;
+        lastResults = [];
+        liveFrames = 0;
+        setBusy(false);
+        setStatus(statusEl.textContent, 1);
+        cameraButton.textContent = "Use webcam";
+        cameraButton.classList.remove("primary");
+      }
+
+      cameraButton.onclick = async () => {
+        if (live) {
+          stopCamera();
+          setStatus("Webcam stopped.");
+          return;
+        }
+        try {
+          stream = await navigator.mediaDevices.getUserMedia({ video: { width: 640 } });
+          video.srcObject = stream;
+          await video.play();
+          live = true;
+          lastResults = [];
+          liveFrames = 0;
+          cameraButton.textContent = "Stop webcam";
+          cameraButton.classList.add("primary");
+          setStatus(`Live — analysing every ${LIVE_INTERVAL_MS / 1000}s…`);
+          previewLoop();
+          liveLoop();
+        } catch (error) {
+          stopCamera();
+          setStatus(`Webcam unavailable: ${error.message}`);
+        }
+      };
+
+      renderScores(null);
+      dotEl.classList.add("busy");
+
+      window.rmn
+        .loadModels(setStatus)
+        .then(() => {
+          pickButton.disabled = false;
+          cameraButton.disabled = false;
+          setBusy(false);
+          setStatus("Ready — choose an image or use your webcam.", 1);
+        })
+        .catch((error) => {
+          setBusy(false);
+          dotEl.classList.remove("ready");
+          setStatus(`Failed to load: ${error.message}`, 0);
+        });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Adds an in-browser facial expression recognition demo, deployed as a static Hugging Face Space at
[huggingface.co/spaces/phamquiluan/ResidualMaskingNetwork](https://huggingface.co/spaces/phamquiluan/ResidualMaskingNetwork).

Inference runs client-side through ONNX Runtime Web, so images never leave the visitor's machine
and the Space costs nothing to host. Hugging Face now requires PRO for Gradio and Docker Spaces;
static Spaces remain free, which is why this is plain HTML/JS rather than Gradio.

## What's here

| File | Purpose |
|---|---|
| `space/app.js` | Browser port of the `rmn` pipeline: YuNet detection, crop, classification |
| `space/index.html` | UI — image upload, webcam mode, probability panel, activity indicators |
| `space/README.md` | Space card (static SDK, linked to the model repo) |

The classifier is served from the model repo as `onnx/resmasking_int8.onnx`, an int8 export of the
same checkpoint the `rmn` package uses (526 MB to 132 MB, calibrated on FER2013 training images).
On the FER2013 private test split the quantised model scores within noise of the fp32 export
(50.7% vs 50.3% on a fixed 300-image subset), so the size reduction is effectively free.

## Fidelity to the Python package

The JavaScript reimplements `rmn`'s preprocessing rather than approximating it: OpenCV's
BGR-to-grayscale weights, the 1.1x square expansion from `convert_to_square`, numpy's
edge-truncating crop, OpenCV's bilinear pixel-center mapping, and the plain `/255` scaling from
`transforms.ToTensor()`.

Checked against a Python twin of the same pipeline on the deployed page: **0px box drift** and
**under 0.002** absolute difference on every class probability.

Face detection letterboxes to 640x640 because the YuNet ONNX has a fixed input shape; a plain
square resize would stretch non-square photos and shift the boxes.

## Webcam mode

Analyses a frame every 2.5s rather than every frame — at ~0.9s per inference, per-frame analysis
would queue up faster than it drains. The period is measured start-to-start so the cadence holds
steady, and a run that overruns it delays the next rather than overlapping. The preview repaints
at display rate with the latest boxes overlaid. Inference pauses while the tab is hidden.

A pulsing dot and sweeping bar show inference in flight, the bar then drains toward the next run,
and the status line reports frame number, face count, top emotion and per-frame time. Those
animations use `transform`/`opacity` so they stay on the compositor — WASM inference blocks the
main thread, and a `width` or `background-position` animation would freeze exactly when it needs
to show progress.

## Verification

Tested in headless Chromium against the deployed Space, with a fake webcam feeding a real face:

- still image: 1 face, 0.9s, matches the Python twin to 0px / 0.002
- cadence: start-to-start 2.5s across runs, no overlap, stop halts inference
- indicators: busy windows 0.85–0.90s (matching inference time), countdown animates, frame counter advances
- no console errors, no failed requests

## Known limitation

The video preview freezes for ~0.9s during each inference, since ONNX Runtime runs on the main
thread. Moving inference into a Web Worker would make the preview smooth; that's a contained
follow-up in `space/app.js`.
